### PR TITLE
Fix frontmatter for 'implementing-commands' page

### DIFF
--- a/src/content/docs/en/implementing-commands.mdx
+++ b/src/content/docs/en/implementing-commands.mdx
@@ -1,5 +1,7 @@
-Title: "Writing Redis Commands"
-Description: ""
+---
+title: "Writing Redis Commands"
+description: ""
+---
 
 import Alert from '../../../components/Alerts/Alert.astro';
 


### PR DESCRIPTION
Fixes page header for `/implementing-commands`.

before:
<img width="600" alt="Screenshot 2024-03-03 154634" src="https://github.com/ahmedash95/build-redis-from-scratch-site/assets/18220388/188fa24d-f6ac-4cd2-a509-46cb55dd45ad">


after:
<img width="600" alt="Screenshot 2024-03-03 154700" src="https://github.com/ahmedash95/build-redis-from-scratch-site/assets/18220388/413fcd6b-02c2-4eee-a92f-8b87fb247328">

P.S.
I was doing [codecrafters' "Build your own Redis"](https://app.codecrafters.io/courses/redis/overview) and found this resource which helped me undestand some parts. Thank you ya Ashraf :)